### PR TITLE
Extend Location properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Then, just add the dependency in your _build.gradle_ (module):
 
 ```groovy
 dependencies {
-    implementation 'com.github.GeotecINIT:WearOSSensors:1.0.0'
+    implementation 'com.github.GeotecINIT:WearOSSensors:1.1.0'
 }
 ```
 

--- a/wearossensors/build.gradle
+++ b/wearossensors/build.gradle
@@ -38,7 +38,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.GeotecINIT'
             artifactId = 'WearOSSensors'
-            version = '1.0.0'
+            version = '1.1.0'
 
             afterEvaluate {
                 from components.release

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/records/LocationRecord.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/records/LocationRecord.java
@@ -10,19 +10,20 @@ public class LocationRecord extends Record {
     private double latitude;
     private double longitude;
     private double altitude;
-
-    public LocationRecord(long timestamp, double latitude, double longitude, double altitude) {
-        super(WearSensor.LOCATION, timestamp);
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.altitude = altitude;
-    }
+    private float verticalAccuracy;
+    private float horizontalAccuracy;
+    private float speed;
+    private float direction;
 
     public LocationRecord(Location location) {
         super(WearSensor.LOCATION, location.getTime());
         this.latitude = location.getLatitude();
         this.longitude = location.getLongitude();
         this.altitude = location.getAltitude();
+        this.verticalAccuracy = location.getAccuracy();
+        this.horizontalAccuracy = location.getAccuracy();
+        this.speed = location.getSpeed();
+        this.direction = location.getBearing();
     }
 
     public double getLatitude() {
@@ -35,5 +36,21 @@ public class LocationRecord extends Record {
 
     public double getAltitude() {
         return altitude;
+    }
+
+    public float getHorizontalAccuracy() {
+        return horizontalAccuracy;
+    }
+
+    public float getVerticalAccuracy() {
+        return verticalAccuracy;
+    }
+
+    public float getSpeed() {
+        return speed;
+    }
+
+    public float getDirection() {
+        return direction;
     }
 }

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/records/callbacks/LocationRecordCallback.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/records/callbacks/LocationRecordCallback.java
@@ -17,7 +17,7 @@ public class LocationRecordCallback extends AbstractRecordCallback<LocationRecor
     @Override
     protected byte[] encodeRecords(List<LocationRecord> records) {
         int size = records.size();
-        byte[] bytes = new byte[Integer.BYTES + (Double.BYTES * 3 + Long.BYTES) * size];
+        byte[] bytes = new byte[Integer.BYTES + (Double.BYTES * 3 + Float.BYTES * 4 + Long.BYTES) * size];
 
         ByteBuffer buff = ByteBuffer.wrap(bytes);
         buff.putInt(size);
@@ -25,6 +25,10 @@ public class LocationRecordCallback extends AbstractRecordCallback<LocationRecor
             buff.putDouble(record.getLatitude());
             buff.putDouble(record.getLongitude());
             buff.putDouble(record.getAltitude());
+            buff.putFloat(record.getVerticalAccuracy());
+            buff.putFloat(record.getHorizontalAccuracy());
+            buff.putFloat(record.getSpeed());
+            buff.putFloat(record.getDirection());
             buff.putLong(record.getTimestamp());
         }
 


### PR DESCRIPTION
This PR modifies the `LocationRecord` by adding more properties to it. The new properties are the following:

- `verticalAccuracy`: estimated error in the latitude.
- `horizontalAccuracy`: estimated error in the longitude.
- `speed`: estimated device's speed when the location was acquired.
- `direction`: estimated device's direction when the location was acquired.