### PR TITLE
Deploy to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WearOS Sensors
-[![](https://jitpack.io/v/GeotecINIT/WearOSSensors.svg)](https://jitpack.io/#GeotecINIT/WearOSSensors)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.geotecinit/wear-os-sensors/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.geotecinit/wear-os-sensors)
 
-The _wearossensors_ library is an Android WearOS library that allows to collect data from the IMU sensors
+The _wear-os-sensors_ library is an Android WearOS library that allows to collect data from the IMU sensors
 (i.e., accelerometer and gyroscope), the magnetometer, the heart rate, and the GPS of an Android WearOS
 smartwatch (if the corresponding sensor is available in the device).
 
@@ -18,46 +18,17 @@ then receive the collected data from the smartwatch.
 The data collection can be started both from the smartwatch and from the paired smartphone. In addition,
 the library offers a way to communicate with the smartphone by sending messages.
 
-The _wearossensors_ library uses and extends the functionality of the Android 
-[_backgroundsensors_](https://github.com/GeoTecINIT/BackgroundSensors) library, and therefore, it is safe to carry out
+The _wear-os-sensors_ library uses and extends the functionality of the Android 
+[_background-sensors_](https://github.com/GeoTecINIT/BackgroundSensors) library, and therefore, it is safe to carry out
 the data collection in the background (i.e., when the app is not in the foreground, or the smartwatch is idle).
 
 
 ## Installation
-To install the library you have to add the [Jitpack](https://jitpack.io) repository to the file where your project
-declares the URLs of the external repositories where the dependencies are looked for:
-
-<details>
-  <summary>build.gradle (project)</summary>
-
-```groovy
-allprojects {
-    repositories {
-        // ...
-        maven { url 'https://jitpack.io' }
-    }
-}
-```
-</details>
-
-<details>
-  <summary>settings.gradle</summary>
-
-```groovy
-dependencyResolutionManagement {
-    repositories {
-        // ...
-        maven { url 'https://jitpack.io' }
-    }
-}
-```
-</details>
-
-Then, just add the dependency in your _build.gradle_ (module):
+To install the library you have to add the dependency in your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'com.github.GeotecINIT:WearOSSensors:1.1.0'
+    implementation 'io.github.geotecinit:wear-os-sensors:1.0.0'
 }
 ```
 
@@ -215,7 +186,7 @@ public class MainActivity extends Activity {
 ```
 
 > **Note**: Here we are using [`Sensor`](#sensor) and [`CollectionConfiguration`](#collectionconfiguration)
-> from [_backgroundsensors_](https://github.com/GeoTecINIT/BackgroundSensors).
+> from [_background-sensors_](https://github.com/GeoTecINIT/BackgroundSensors).
 > Check its documentation for more information.
 
 ### Messaging
@@ -273,7 +244,7 @@ of the demo application.
 | `LOCATION`      | Represents the GPS.                  |
 
 ### `SensorManager`
-Refer to the [_backgroundsensors_](https://github.com/GeoTecINIT/BackgroundSensors#sensormanager) documentation.
+Refer to the [_background-sensors_](https://github.com/GeoTecINIT/BackgroundSensors#sensormanager) documentation.
 
 ### [`PermissionsManager`](wearossensors/src/main/java/es/uji/geotec/wearossensors/permissions/PermissionsManager.java)
 | **Static Method**                                                       | **Return type**     | **Description**                                                                                                                                                        |
@@ -298,10 +269,10 @@ Refer to the [_backgroundsensors_](https://github.com/GeoTecINIT/BackgroundSenso
 | `sendStopCommand(Sensor sensor)`                          | `void`          | Sends a command to the smartphone to stop the collection of the specified sensor in the smartwatch.           |
 
 #### CollectionConfiguration
-Refer to the [_backgroundsensors_](https://github.com/GeoTecINIT/BackgroundSensors#collectionconfiguration) documentation.
+Refer to the [_background-sensors_](https://github.com/GeoTecINIT/BackgroundSensors#collectionconfiguration) documentation.
 
 #### Sensor
-Refer to the [_backgroundsensors_](https://github.com/GeoTecINIT/BackgroundSensors) documentation.
+Refer to the [_background-sensors_](https://github.com/GeoTecINIT/BackgroundSensors) documentation.
 
 ### [`PlainMessageClient`](wearossensors/src/main/java/es/uji/geotec/wearossensors/plainmessage/PlainMessageClient.java)
 | **Method**                                        | **Return type** | **Description**                                     |

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
     }
 }
 rootProject.name = "WearOSSensors"

--- a/wearossensors/build.gradle
+++ b/wearossensors/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-wearable:17.1.0'
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'com.google.android.gms:play-services-location:20.0.0'
-    api 'com.github.GeotecINIT:BackgroundSensors:1.0.1'
+    api 'io.github.geotecinit:background-sensors:1.0.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/wearossensors/build.gradle
+++ b/wearossensors/build.gradle
@@ -1,6 +1,7 @@
 plugins {
-    id 'maven-publish'
     id 'com.android.library'
+    id 'maven-publish'
+    id 'signing'
 }
 
 android {
@@ -36,23 +37,23 @@ android {
 publishing {
     publications {
         release(MavenPublication) {
-            groupId = 'com.github.GeotecINIT'
-            artifactId = 'WearOSSensors'
-            version = '1.1.0'
+            groupId = 'io.github.geotecinit'
+            artifactId = 'wear-os-sensors'
+            version = '1.0.0'
 
             afterEvaluate {
                 from components.release
             }
 
             pom {
-                name = 'WearOSSensors'
-                description = 'The WearOSSensors library is an Android library that allows to' +
+                name = 'WearOS Sensors'
+                description = 'The WearOS Sensors library is an Android library that allows to' +
                         ' collect data from the sensors of an Android WearOS Smartwatch.' +
                         ' Concretely, it can collect samples from the IMU sensors (i.e., accelerometer and gyroscope),' +
                         ' the magnetometer, the heart rate, and the GPS (if they are present in the device).' +
                         ' The collected data is sent to a paired smartphone. It also allow to communicate' +
                         ' with the smartphone by sending messages.'
-                url = 'https://github.com/GeoTecINIT/BackgroundSensors'
+                url = 'https://github.com/GeoTecINIT/WearOSSensors'
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
@@ -74,6 +75,21 @@ publishing {
             }
         }
     }
+
+    repositories {
+        maven {
+            name = 'central'
+            url = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
+            credentials {
+                username = ossrhUsername
+                password = ossrhPassword
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.release
 }
 
 dependencies {


### PR DESCRIPTION
This PR contains the required changes to the build configuration to be able to deploy the artifact to the Maven Central repository. It also replaces the `background-sensors` dependency from Jitpack to the one from Maven Central.