### PR TITLE
Recording service injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To install the library you have to add the dependency in your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'io.github.geotecinit:wear-os-sensors:1.0.0'
+    implementation 'io.github.geotecinit:wear-os-sensors:1.1.0'
 }
 ```
 

--- a/wearossensors/build.gradle
+++ b/wearossensors/build.gradle
@@ -31,6 +31,10 @@ android {
             withJavadocJar()
             withSourcesJar()
         }
+
+        singleVariant('debug') {
+            withSourcesJar()
+        }
     }
 }
 
@@ -39,7 +43,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'io.github.geotecinit'
             artifactId = 'wear-os-sensors'
-            version = '1.0.0'
+            version = '1.1.0'
 
             afterEvaluate {
                 from components.release
@@ -74,6 +78,16 @@ publishing {
                 }
             }
         }
+
+        debug(MavenPublication) {
+            groupId = 'io.github.geotecinit'
+            artifactId = 'wear-os-sensors'
+            version = '1.1.0-debug'
+
+            afterEvaluate {
+                from components.debug
+            }
+        }
     }
 
     repositories {
@@ -96,7 +110,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-wearable:17.1.0'
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'com.google.android.gms:play-services-location:20.0.0'
-    api 'io.github.geotecinit:background-sensors:1.0.0'
+    api 'io.github.geotecinit:background-sensors:1.1.0-debug'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/wearossensors/build.gradle
+++ b/wearossensors/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-wearable:17.1.0'
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'com.google.android.gms:play-services-location:20.0.0'
-    api 'io.github.geotecinit:background-sensors:1.1.0-debug'
+    api 'io.github.geotecinit:background-sensors:1.1.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/command/CommandClient.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/command/CommandClient.java
@@ -38,7 +38,7 @@ public class CommandClient {
         sendCommand("stop-" + sensor.toString().toLowerCase());
     }
 
-    protected void sendCommand(String commandName, int sensorDelay, int batchSize) {
+    private void sendCommand(String commandName, int sensorDelay, int batchSize) {
         String command = commandFromParameters(commandName, sensorDelay, batchSize);
         sendCommand(command);
     }

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/command/CommandClient.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/command/CommandClient.java
@@ -38,7 +38,7 @@ public class CommandClient {
         sendCommand("stop-" + sensor.toString().toLowerCase());
     }
 
-    private void sendCommand(String commandName, int sensorDelay, int batchSize) {
+    protected void sendCommand(String commandName, int sensorDelay, int batchSize) {
         String command = commandFromParameters(commandName, sensorDelay, batchSize);
         sendCommand(command);
     }

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/AbstractMessagingHandler.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/AbstractMessagingHandler.java
@@ -16,7 +16,7 @@ import es.uji.geotec.wearossensors.notifications.NotificationProvider;
 import es.uji.geotec.wearossensors.permissions.PermissionsManager;
 import es.uji.geotec.wearossensors.records.callbacks.RecordCallbackProvider;
 import es.uji.geotec.wearossensors.sensor.WearSensor;
-import es.uji.geotec.wearossensors.services.WearSensorRecordingService;
+import es.uji.geotec.wearossensors.services.RecordingServiceManager;
 
 public abstract class AbstractMessagingHandler {
 
@@ -25,7 +25,7 @@ public abstract class AbstractMessagingHandler {
 
     public AbstractMessagingHandler(Context context) {
         this.context = context;
-        this.serviceManager = new ServiceManager(context, WearSensorRecordingService.class);
+        this.serviceManager = new ServiceManager(context, RecordingServiceManager.getService(context));
     }
 
     public void handleMessage(MessageEvent event) {

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/services/RecordingServiceManager.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/services/RecordingServiceManager.java
@@ -1,0 +1,30 @@
+package es.uji.geotec.wearossensors.services;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+public class RecordingServiceManager {
+
+    private static final String PREFERENCES_NAME = "WEAROSSENSORS_PREFS";
+    private static final String RECORDING_SERVICE_KEY = "RECORDING_SERVICE";
+
+    public static void setService(Context context, Class<?> permissionsActivity) {
+        SharedPreferences preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putString(RECORDING_SERVICE_KEY, permissionsActivity.getName());
+        editor.apply();
+    }
+
+    public static Class<?> getService(Context context) {
+        SharedPreferences preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
+        String className = preferences.getString(RECORDING_SERVICE_KEY, WearSensorRecordingService.class.getName());
+
+        Class<?> permissionsActivityClass = null;
+        try {
+            permissionsActivityClass = Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+        return permissionsActivityClass;
+    }
+}


### PR DESCRIPTION
The changes included in this PR allow using a custom recording service (which extends the `SensorRecordingService`). Previously, the service was hardcoded, and now, it can be provided from the main application. This allows customizing the behaviour of the service before and after the data collection.