### PR TITLE
Support for Wear OS 4 (Android 13 - API 33)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,12 +12,12 @@ android {
         }
     }
 
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "es.uji.geotec.wearossensorsdemo"
         minSdk 23
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -30,6 +30,7 @@ android {
             signingConfig signingConfigs.release
         }
     }
+    namespace 'es.uji.geotec.wearossensorsdemo'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,9 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.BODY_SENSORS" />
+    <uses-permission android:name="android.permission.BODY_SENSORS_BACKGROUND" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <uses-feature android:name="android.hardware.type.watch" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="es.uji.geotec.wearossensorsdemo">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.BODY_SENSORS" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/app/src/main/java/es/uji/geotec/wearossensorsdemo/MainActivity.java
+++ b/app/src/main/java/es/uji/geotec/wearossensorsdemo/MainActivity.java
@@ -53,8 +53,11 @@ public class MainActivity extends Activity {
     }
 
     public void onStartSingleCommandTap(View view) {
+        WearSensor selectedSensor = (WearSensor) sensorSpinner.getSelectedItem();
+        boolean requested = PermissionsManager.launchPermissionsRequestIfNeeded(this, selectedSensor.getRequiredPermissions());
+        if (requested) return;
+
         toggleVisibility(stopSingle, startSingle);
-        Sensor selectedSensor = (Sensor) sensorSpinner.getSelectedItem();
         sensorSpinner.setEnabled(false);
 
         CollectionConfiguration config = new CollectionConfiguration(

--- a/app/src/main/java/es/uji/geotec/wearossensorsdemo/MainActivity.java
+++ b/app/src/main/java/es/uji/geotec/wearossensorsdemo/MainActivity.java
@@ -2,6 +2,7 @@ package es.uji.geotec.wearossensorsdemo;
 
 import android.app.Activity;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -50,6 +51,9 @@ public class MainActivity extends Activity {
         });
 
         PermissionsManager.setPermissionsActivity(this, RequestPermissionsActivity.class);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            PermissionsManager.launchRequiredPermissionsRequest(this);
+        }
     }
 
     public void onStartSingleCommandTap(View view) {

--- a/app/src/main/java/es/uji/geotec/wearossensorsdemo/RequestPermissionsActivity.java
+++ b/app/src/main/java/es/uji/geotec/wearossensorsdemo/RequestPermissionsActivity.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import es.uji.geotec.wearossensors.intent.IntentManager;
 import es.uji.geotec.wearossensors.permissions.PermissionsManager;
 import es.uji.geotec.wearossensors.permissions.PermissionsResultClient;
 
@@ -22,6 +23,10 @@ public class RequestPermissionsActivity extends FragmentActivity {
     TextView descriptionText;
     ProgressBar progressBar;
     ImageView checkIcon, failIcon;
+
+    ArrayList<String> permissions;
+    ArrayList<String> specialPermissions;
+    boolean specialPermissionsRequested = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -37,8 +42,17 @@ public class RequestPermissionsActivity extends FragmentActivity {
         delayer.schedule(new TimerTask() {
             @Override
             public void run() {
-                ArrayList<String> permissionsToRequest = PermissionsManager.permissionsToRequestFromIntent(getIntent());
-                requestPermissions(permissionsToRequest);
+                permissions = PermissionsManager.permissionsToRequestFromIntent(getIntent());
+                specialPermissions = PermissionsManager.specialPermissionsToRequestFromIntent(getIntent());
+
+                if (permissions.size() != 0) {
+                    requestPermissions(permissions);
+                } else if (specialPermissions.size() != 0) {
+                    specialPermissionsRequested = true;
+                    requestPermissions(specialPermissions);
+                } else {
+                    finishDeferred();
+                }
             }
         }, 500);
     }
@@ -59,26 +73,49 @@ public class RequestPermissionsActivity extends FragmentActivity {
             }
         }
 
-        progressBar.setVisibility(View.GONE);
-
-        PermissionsResultClient permissionsResultClient = new PermissionsResultClient(this);
-        if (permissionsRejected.size() == 0) {
-            permissionsResultClient.sendPermissionsSuccessfulResponse(getIntent());
-            descriptionText.setText("Thanks! :D");
-            checkIcon.setVisibility(View.VISIBLE);
-            finishDeferred();
+        if (permissionsRejected.size() != 0) {
+            requestFailed(permissionsRejected);
             return;
         }
 
-        String failureMessage = buildFailureMessage(permissionsRejected);
-        permissionsResultClient.sendPermissionsFailureResponse(getIntent(), failureMessage);
-        descriptionText.setText("Permissions denied :(");
-        failIcon.setVisibility(View.VISIBLE);
-        finishDeferred();
+        if (!specialPermissionsRequested && specialPermissions.size() != 0) {
+            Timer delayer = new Timer();
+            delayer.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    requestPermissions(specialPermissions);
+                    specialPermissionsRequested = true;
+                }
+            }, 1000);
+            return;
+        }
+
+        requestSucceeded();
     }
 
     private void requestPermissions(ArrayList<String> permissions) {
         PermissionsManager.requestPermissions(this, permissions);
+    }
+
+    private void requestSucceeded() {
+        PermissionsResultClient permissionsResultClient = new PermissionsResultClient(this);
+        boolean remoteRequest = IntentManager.isRemoteRequest(getIntent());
+        if (remoteRequest) {
+            permissionsResultClient.sendPermissionsSuccessfulResponse(getIntent());
+        }
+
+        updateUI(true);
+    }
+
+    private void requestFailed(ArrayList<String> permissionsRejected) {
+        PermissionsResultClient permissionsResultClient = new PermissionsResultClient(this);
+        boolean remoteRequest = IntentManager.isRemoteRequest(getIntent());
+        if (remoteRequest) {
+            String failureMessage = buildFailureMessage(permissionsRejected);
+            permissionsResultClient.sendPermissionsFailureResponse(getIntent(), failureMessage);
+        }
+
+        updateUI(false);
     }
 
     private String buildFailureMessage(ArrayList<String> failures) {
@@ -92,6 +129,18 @@ public class RequestPermissionsActivity extends FragmentActivity {
         }
 
         return sb.toString();
+    }
+
+    private void updateUI(boolean success) {
+        progressBar.setVisibility(View.GONE);
+        if (success) {
+            descriptionText.setText("Thanks! :D");
+            checkIcon.setVisibility(View.VISIBLE);
+        } else {
+            descriptionText.setText("Permissions denied :(");
+            failIcon.setVisibility(View.VISIBLE);
+        }
+        finishDeferred();
     }
 
     private void finishDeferred() {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.1.2' apply false
-    id 'com.android.library' version '7.1.2' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jul 28 15:57:06 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/wearossensors/build.gradle
+++ b/wearossensors/build.gradle
@@ -112,10 +112,10 @@ tasks.withType(Sign) {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-wearable:17.1.0'
+    implementation 'com.google.android.gms:play-services-wearable:18.1.0'
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'com.google.android.gms:play-services-location:20.0.0'
-    api 'io.github.geotecinit:background-sensors:1.2.0'
+    api 'io.github.geotecinit:background-sensors:1.3.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/wearossensors/build.gradle
+++ b/wearossensors/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -36,6 +36,7 @@ android {
             withSourcesJar()
         }
     }
+    namespace 'es.uji.geotec.wearossensors'
 }
 
 version = '1.1.0'

--- a/wearossensors/build.gradle
+++ b/wearossensors/build.gradle
@@ -39,7 +39,7 @@ android {
     namespace 'es.uji.geotec.wearossensors'
 }
 
-version = '1.1.0'
+version = '1.2.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 publishing {

--- a/wearossensors/src/main/AndroidManifest.xml
+++ b/wearossensors/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>
         <service android:name=".services.SensorMessagingListenerService" android:exported="true">

--- a/wearossensors/src/main/AndroidManifest.xml
+++ b/wearossensors/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="es.uji.geotec.wearossensors">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/intent/IntentBuilder.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/intent/IntentBuilder.java
@@ -1,0 +1,54 @@
+package es.uji.geotec.wearossensors.intent;
+
+import android.content.Context;
+import android.content.Intent;
+
+import java.util.ArrayList;
+
+import es.uji.geotec.wearossensors.messaging.ResultMessagingProtocol;
+
+public class IntentBuilder {
+
+    public static final String PERMISSIONS_EXTRAS = "PERMISSIONS";
+    public static final String PERMISSIONS_EXTRAS_SPECIAL = "PERMISSIONS_SPECIAL";
+    public static final String NODE = "NODE";
+    public static final String PROTOCOL = "PROTOCOL";
+
+    private Intent intent;
+
+    public IntentBuilder() {
+        this.intent = new Intent();
+    }
+
+    public IntentBuilder setContext(Context context, Class<?> targetActivity) {
+        this.intent.setClass(context, targetActivity);
+        this.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        return this;
+    }
+
+    public IntentBuilder setPermissionsToRequest(ArrayList<String> permissions) {
+        ArrayList<String> normalPermissions = new ArrayList<>();
+        ArrayList<String> specialPermissions = new ArrayList<>();
+        for (String permission : permissions) {
+            if (permission.contains("BACKGROUND")) {
+                specialPermissions.add(permission);
+            } else {
+                normalPermissions.add(permission);
+            }
+        }
+
+        this.intent.putStringArrayListExtra(PERMISSIONS_EXTRAS, normalPermissions);
+        this.intent.putStringArrayListExtra(PERMISSIONS_EXTRAS_SPECIAL, specialPermissions);
+        return this;
+    }
+
+    public IntentBuilder setRemoteNodeInfo(String sourceNodeId, ResultMessagingProtocol resultProtocol) {
+        this.intent.putExtra(NODE, sourceNodeId);
+        this.intent.putExtra(PROTOCOL, resultProtocol);
+        return this;
+    }
+
+    public Intent build() {
+        return this.intent;
+    }
+}

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/AbstractMessagingHandler.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/AbstractMessagingHandler.java
@@ -116,7 +116,9 @@ public abstract class AbstractMessagingHandler {
         return sensorManager.isSensorAvailable(wearSensor);
     }
 
-    protected abstract ArrayList<String> getRequiredPermissions();
+    private ArrayList<String> getRequiredPermissions() {
+        return getWearSensorType().getRequiredPermissions();
+    };
 
     protected abstract MessagingProtocol getProtocol();
 

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/AccelerometerMessagingHandler.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/AccelerometerMessagingHandler.java
@@ -2,8 +2,6 @@ package es.uji.geotec.wearossensors.messaging.handlers;
 
 import android.content.Context;
 
-import java.util.ArrayList;
-
 import es.uji.geotec.wearossensors.messaging.MessagingProtocol;
 import es.uji.geotec.wearossensors.messaging.ResultMessagingProtocol;
 import es.uji.geotec.wearossensors.sensor.WearSensor;
@@ -12,11 +10,6 @@ public class AccelerometerMessagingHandler extends AbstractMessagingHandler {
 
     public AccelerometerMessagingHandler(Context context) {
         super(context);
-    }
-
-    @Override
-    protected ArrayList<String> getRequiredPermissions() {
-        return new ArrayList<>();
     }
 
     @Override

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/GyroscopeMessagingHandler.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/GyroscopeMessagingHandler.java
@@ -2,8 +2,6 @@ package es.uji.geotec.wearossensors.messaging.handlers;
 
 import android.content.Context;
 
-import java.util.ArrayList;
-
 import es.uji.geotec.wearossensors.messaging.MessagingProtocol;
 import es.uji.geotec.wearossensors.messaging.ResultMessagingProtocol;
 import es.uji.geotec.wearossensors.sensor.WearSensor;
@@ -11,11 +9,6 @@ import es.uji.geotec.wearossensors.sensor.WearSensor;
 public class GyroscopeMessagingHandler extends AbstractMessagingHandler {
 
     public GyroscopeMessagingHandler(Context context) { super(context); };
-
-    @Override
-    protected ArrayList<String> getRequiredPermissions() {
-        return new ArrayList<>();
-    }
 
     @Override
     protected MessagingProtocol getProtocol() {

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/HeartRateMessagingHandler.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/HeartRateMessagingHandler.java
@@ -1,10 +1,6 @@
 package es.uji.geotec.wearossensors.messaging.handlers;
 
-import android.Manifest;
 import android.content.Context;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import es.uji.geotec.wearossensors.messaging.MessagingProtocol;
 import es.uji.geotec.wearossensors.messaging.ResultMessagingProtocol;
@@ -14,11 +10,6 @@ public class HeartRateMessagingHandler extends AbstractMessagingHandler {
 
     public HeartRateMessagingHandler(Context context) {
         super(context);
-    }
-
-    @Override
-    protected ArrayList<String> getRequiredPermissions() {
-        return new ArrayList<>(Arrays.asList(Manifest.permission.BODY_SENSORS));
     }
 
     @Override

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/LocationMessagingHandler.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/LocationMessagingHandler.java
@@ -1,10 +1,6 @@
 package es.uji.geotec.wearossensors.messaging.handlers;
 
-import android.Manifest;
 import android.content.Context;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import es.uji.geotec.wearossensors.messaging.MessagingProtocol;
 import es.uji.geotec.wearossensors.messaging.ResultMessagingProtocol;
@@ -14,11 +10,6 @@ public class LocationMessagingHandler extends AbstractMessagingHandler{
 
     public LocationMessagingHandler(Context context) {
         super(context);
-    }
-
-    @Override
-    protected ArrayList<String> getRequiredPermissions() {
-        return new ArrayList<>(Arrays.asList(Manifest.permission.ACCESS_FINE_LOCATION));
     }
 
     @Override

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/MagnetometerMessagingHandler.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/messaging/handlers/MagnetometerMessagingHandler.java
@@ -2,8 +2,6 @@ package es.uji.geotec.wearossensors.messaging.handlers;
 
 import android.content.Context;
 
-import java.util.ArrayList;
-
 import es.uji.geotec.wearossensors.messaging.MessagingProtocol;
 import es.uji.geotec.wearossensors.messaging.ResultMessagingProtocol;
 import es.uji.geotec.wearossensors.sensor.WearSensor;
@@ -12,11 +10,6 @@ public class MagnetometerMessagingHandler extends AbstractMessagingHandler {
 
     public MagnetometerMessagingHandler(Context context) {
         super(context);
-    }
-
-    @Override
-    protected ArrayList<String> getRequiredPermissions() {
-        return new ArrayList<>();
     }
 
     @Override

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/permissions/PermissionsManager.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/permissions/PermissionsManager.java
@@ -1,6 +1,7 @@
 package es.uji.geotec.wearossensors.permissions;
 
 import android.app.Activity;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -19,7 +20,11 @@ public class PermissionsManager {
     public static final int PERMISSIONS_RC = 51;
 
     public static ArrayList<String> permissionsToRequestFromIntent(Intent intent) {
-        return intent.getStringArrayListExtra(IntentManager.PERMISSIONS_EXTRAS);
+        return IntentManager.permissionsFromIntent(intent);
+    }
+
+    public static ArrayList<String> specialPermissionsToRequestFromIntent(Intent intent) {
+        return IntentManager.specialPermissionsFromIntent(intent);
     }
 
     public static ArrayList<String> permissionsToBeRequested(Context context, ArrayList<String> required) {
@@ -32,6 +37,25 @@ public class PermissionsManager {
         }
 
         return toBeRequested;
+    }
+
+    public static boolean launchPermissionsRequestIfNeeded(Activity activity, ArrayList<String> permissions) {
+        ArrayList<String> permissionsToBeRequested = permissionsToBeRequested(activity, permissions);
+        if (permissionsToBeRequested.size() == 0) {
+            return false;
+        }
+
+        PendingIntent intent = IntentManager.pendingIntentFromPermissionsToRequest(
+                activity,
+                getPermissionsActivity(activity),
+                permissionsToBeRequested
+        );
+        try {
+            intent.send();
+        } catch (PendingIntent.CanceledException e) {
+            e.printStackTrace();
+        }
+        return true;
     }
 
     public static void requestPermissions(Activity activity, ArrayList<String> permissions) {

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/permissions/PermissionsManager.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/permissions/PermissionsManager.java
@@ -1,15 +1,19 @@
 package es.uji.geotec.wearossensors.permissions;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.os.Build;
 
+import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 import es.uji.geotec.wearossensors.intent.IntentManager;
 
@@ -37,6 +41,27 @@ public class PermissionsManager {
         }
 
         return toBeRequested;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    public static void launchRequiredPermissionsRequest(Activity activity) {
+        if (ActivityCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+
+        PendingIntent intent = IntentManager.pendingIntentFromPermissionsToRequest(
+                activity,
+                getPermissionsActivity(activity),
+                new ArrayList<>(Collections.singletonList(
+                        Manifest.permission.POST_NOTIFICATIONS
+                ))
+        );
+
+        try {
+            intent.send();
+        } catch (PendingIntent.CanceledException e) {
+            e.printStackTrace();
+        }
     }
 
     public static boolean launchPermissionsRequestIfNeeded(Activity activity, ArrayList<String> permissions) {

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/sensor/WearSensor.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/sensor/WearSensor.java
@@ -1,21 +1,59 @@
 package es.uji.geotec.wearossensors.sensor;
 
+import static android.os.Build.VERSION_CODES.TIRAMISU;
+
+import android.Manifest;
 import android.content.pm.PackageManager;
+import android.os.Build;
+
+import java.util.ArrayList;
+import java.util.Collections;
 
 import es.uji.geotec.backgroundsensors.sensor.Sensor;
 
 public enum WearSensor implements Sensor {
-    ACCELEROMETER(android.hardware.Sensor.TYPE_ACCELEROMETER, PackageManager.FEATURE_SENSOR_ACCELEROMETER),
-    GYROSCOPE(android.hardware.Sensor.TYPE_GYROSCOPE, PackageManager.FEATURE_SENSOR_GYROSCOPE),
-    MAGNETOMETER(android.hardware.Sensor.TYPE_MAGNETIC_FIELD, PackageManager.FEATURE_SENSOR_COMPASS),
-    HEART_RATE(android.hardware.Sensor.TYPE_HEART_RATE, PackageManager.FEATURE_SENSOR_HEART_RATE),
-    LOCATION(-1, PackageManager.FEATURE_LOCATION_GPS);
+    ACCELEROMETER(
+            android.hardware.Sensor.TYPE_ACCELEROMETER,
+            PackageManager.FEATURE_SENSOR_ACCELEROMETER,
+            new ArrayList<>()
+            ),
+    GYROSCOPE(
+            android.hardware.Sensor.TYPE_GYROSCOPE,
+            PackageManager.FEATURE_SENSOR_GYROSCOPE,
+            new ArrayList<>()
+    ),
+    MAGNETOMETER(
+            android.hardware.Sensor.TYPE_MAGNETIC_FIELD,
+            PackageManager.FEATURE_SENSOR_COMPASS,
+            new ArrayList<>()
+    ),
+    HEART_RATE(
+            android.hardware.Sensor.TYPE_HEART_RATE,
+            PackageManager.FEATURE_SENSOR_HEART_RATE,
+            new ArrayList<>(Collections.singletonList(Manifest.permission.BODY_SENSORS))
+    ),
+    LOCATION(
+            -1,
+            PackageManager.FEATURE_LOCATION_GPS,
+            new ArrayList<>(Collections.singletonList(Manifest.permission.ACCESS_FINE_LOCATION))
+    );
 
     private int sensorType;
     private String feature;
-    WearSensor(int sensorType, String feature) {
+    private ArrayList<String> requiredPermissions;
+
+    WearSensor(int sensorType, String feature, ArrayList<String> requiredPermissions) {
         this.sensorType = sensorType;
         this.feature = feature;
+        this.requiredPermissions = requiredPermissions;
+
+        if (this.sensorType == android.hardware.Sensor.TYPE_HEART_RATE && Build.VERSION.SDK_INT >= TIRAMISU) {
+            this.requiredPermissions.add(Manifest.permission.BODY_SENSORS_BACKGROUND);
+        }
+
+        if (this.sensorType == -1 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            this.requiredPermissions.add(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+        }
     }
 
     @Override
@@ -26,5 +64,9 @@ public enum WearSensor implements Sensor {
     @Override
     public String getSystemFeature() {
         return feature;
+    }
+
+    public ArrayList<String> getRequiredPermissions() {
+        return this.requiredPermissions;
     }
 }


### PR DESCRIPTION
This PR adds support for using the library in apps running on Wear OS 4 (Android 13 - API 33). The following changes are included:

- Add `PermissionsManager.launchRequiredPermissionsRequest()` method to request the `POST_NOTIFICATIONS` permission in Wear OS 4 devices.
- Add `PermissionsManager.launchPermissionsRequestIfNeeded()` method to request required permissions from the smartwatch (previously, they were launched from the paired smartphone)