### PR TITLE
Integrate two-step permissions request workflow

### DIFF
--- a/app/src/main/java/es/uji/geotec/wearossensorsdemo/RequestPermissionsActivity.java
+++ b/app/src/main/java/es/uji/geotec/wearossensorsdemo/RequestPermissionsActivity.java
@@ -1,6 +1,5 @@
 package es.uji.geotec.wearossensorsdemo;
 
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ImageView;
@@ -10,13 +9,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 
-import java.util.ArrayList;
-import java.util.Timer;
-import java.util.TimerTask;
-
-import es.uji.geotec.wearossensors.intent.IntentManager;
-import es.uji.geotec.wearossensors.permissions.PermissionsManager;
-import es.uji.geotec.wearossensors.permissions.PermissionsResultClient;
+import es.uji.geotec.wearossensors.permissions.handler.PermissionsRequestHandler;
 
 public class RequestPermissionsActivity extends FragmentActivity {
 
@@ -24,9 +17,7 @@ public class RequestPermissionsActivity extends FragmentActivity {
     ProgressBar progressBar;
     ImageView checkIcon, failIcon;
 
-    ArrayList<String> permissions;
-    ArrayList<String> specialPermissions;
-    boolean specialPermissionsRequested = false;
+    private PermissionsRequestHandler handler;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -38,97 +29,15 @@ public class RequestPermissionsActivity extends FragmentActivity {
         checkIcon = findViewById(R.id.checkIcon);
         failIcon = findViewById(R.id.failIcon);
 
-        Timer delayer = new Timer();
-        delayer.schedule(new TimerTask() {
-            @Override
-            public void run() {
-                permissions = PermissionsManager.permissionsToRequestFromIntent(getIntent());
-                specialPermissions = PermissionsManager.specialPermissionsToRequestFromIntent(getIntent());
-
-                if (permissions.size() != 0) {
-                    requestPermissions(permissions);
-                } else if (specialPermissions.size() != 0) {
-                    specialPermissionsRequested = true;
-                    requestPermissions(specialPermissions);
-                } else {
-                    finishDeferred();
-                }
-            }
-        }, 500);
+        handler = new PermissionsRequestHandler(this);
+        handler.onPermissionsResult(this::updateUI);
+        handler.handleRequest();
     }
-
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-
-        if (requestCode != PermissionsManager.PERMISSIONS_RC) {
-            return;
-        }
-
-        ArrayList<String> permissionsRejected = new ArrayList<>();
-        for (int i = 0; i < grantResults.length; i++) {
-            if (grantResults[i] == PackageManager.PERMISSION_DENIED) {
-                permissionsRejected.add(permissions[i]);
-            }
-        }
-
-        if (permissionsRejected.size() != 0) {
-            requestFailed(permissionsRejected);
-            return;
-        }
-
-        if (!specialPermissionsRequested && specialPermissions.size() != 0) {
-            Timer delayer = new Timer();
-            delayer.schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    requestPermissions(specialPermissions);
-                    specialPermissionsRequested = true;
-                }
-            }, 1000);
-            return;
-        }
-
-        requestSucceeded();
-    }
-
-    private void requestPermissions(ArrayList<String> permissions) {
-        PermissionsManager.requestPermissions(this, permissions);
-    }
-
-    private void requestSucceeded() {
-        PermissionsResultClient permissionsResultClient = new PermissionsResultClient(this);
-        boolean remoteRequest = IntentManager.isRemoteRequest(getIntent());
-        if (remoteRequest) {
-            permissionsResultClient.sendPermissionsSuccessfulResponse(getIntent());
-        }
-
-        updateUI(true);
-    }
-
-    private void requestFailed(ArrayList<String> permissionsRejected) {
-        PermissionsResultClient permissionsResultClient = new PermissionsResultClient(this);
-        boolean remoteRequest = IntentManager.isRemoteRequest(getIntent());
-        if (remoteRequest) {
-            String failureMessage = buildFailureMessage(permissionsRejected);
-            permissionsResultClient.sendPermissionsFailureResponse(getIntent(), failureMessage);
-        }
-
-        updateUI(false);
-    }
-
-    private String buildFailureMessage(ArrayList<String> failures) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Permissions rejected: ");
-        String separator = " ";
-        for (String failure : failures) {
-            sb.append(separator);
-            separator = ", ";
-            sb.append(failure);
-        }
-
-        return sb.toString();
+        handler.handleResult(requestCode, permissions, grantResults);
     }
 
     private void updateUI(boolean success) {
@@ -140,16 +49,5 @@ public class RequestPermissionsActivity extends FragmentActivity {
             descriptionText.setText("Permissions denied :(");
             failIcon.setVisibility(View.VISIBLE);
         }
-        finishDeferred();
-    }
-
-    private void finishDeferred() {
-        Timer delayer = new Timer();
-        delayer.schedule(new TimerTask() {
-            @Override
-            public void run() {
-                finish();
-            }
-        }, 1000);
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,7 @@
     android:background="@color/dark_grey"
     tools:context=".MainActivity"
     tools:deviceIds="wear">
-
+    <requestFocus/>
             <LinearLayout
                 android:id="@+id/linear_layout"
                 android:layout_width="match_parent"

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/permissions/handler/PermissionsRequestHandler.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/permissions/handler/PermissionsRequestHandler.java
@@ -1,0 +1,128 @@
+package es.uji.geotec.wearossensors.permissions.handler;
+
+import android.app.Activity;
+import android.content.pm.PackageManager;
+
+import java.util.ArrayList;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import es.uji.geotec.wearossensors.intent.IntentManager;
+import es.uji.geotec.wearossensors.permissions.PermissionsManager;
+import es.uji.geotec.wearossensors.permissions.PermissionsResultClient;
+
+public class PermissionsRequestHandler {
+
+    private Activity activity;
+    private Timer delayer = new Timer();
+    private ArrayList<String> permissions;
+    private ArrayList<String> specialPermissions;
+    private boolean specialPermissionsRequested = false;
+
+    private PermissionsResult permissionsResult;
+
+    public PermissionsRequestHandler(Activity activity) {
+        this.activity = activity;
+    }
+
+    public void handleRequest() {
+        delayer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+            permissions = PermissionsManager.permissionsToRequestFromIntent(activity.getIntent());
+            specialPermissions = PermissionsManager.specialPermissionsToRequestFromIntent(activity.getIntent());
+
+            if (permissions.size() != 0) {
+                PermissionsManager.requestPermissions(activity, permissions);
+            } else if (specialPermissions.size() != 0) {
+                specialPermissionsRequested = true;
+                PermissionsManager.requestPermissions(activity, specialPermissions);
+            } else {
+                finishDeferred();
+            }
+            }
+        }, 500);
+    }
+
+    public void handleResult(int requestCode, String[] permissions, int[] grantResults) {
+        if (requestCode != PermissionsManager.PERMISSIONS_RC) {
+            return;
+        }
+
+        ArrayList<String> permissionsRejected = new ArrayList<>();
+        for (int i = 0; i < grantResults.length; i++) {
+            if (grantResults[i] == PackageManager.PERMISSION_DENIED) {
+                permissionsRejected.add(permissions[i]);
+            }
+        }
+
+        if (permissionsRejected.size() != 0) {
+            requestFailed(permissionsRejected);
+            return;
+        }
+
+        if (!specialPermissionsRequested && specialPermissions.size() != 0) {
+            Timer delayer = new Timer();
+            delayer.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    specialPermissionsRequested = true;
+                    PermissionsManager.requestPermissions(activity, specialPermissions);
+                }
+            }, 1000);
+            return;
+        }
+
+        requestSucceeded();
+    }
+
+    public void onPermissionsResult(PermissionsResult permissionsResult) {
+        this.permissionsResult = permissionsResult;
+    }
+
+    private void requestSucceeded() {
+        PermissionsResultClient permissionsResultClient = new PermissionsResultClient(activity);
+        boolean remoteRequest = IntentManager.isRemoteRequest(activity.getIntent());
+        if (remoteRequest) {
+            permissionsResultClient.sendPermissionsSuccessfulResponse(activity.getIntent());
+        }
+
+        permissionsResult.onPermissionsRequestResult(true);
+        finishDeferred();
+    }
+
+    private void requestFailed(ArrayList<String> permissionsRejected) {
+        PermissionsResultClient permissionsResultClient = new PermissionsResultClient(activity);
+        boolean remoteRequest = IntentManager.isRemoteRequest(activity.getIntent());
+        if (remoteRequest) {
+            String failureMessage = buildFailureMessage(permissionsRejected);
+            permissionsResultClient.sendPermissionsFailureResponse(activity.getIntent(), failureMessage);
+        }
+
+        permissionsResult.onPermissionsRequestResult(false);
+        finishDeferred();
+    }
+
+    private String buildFailureMessage(ArrayList<String> failures) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Permissions rejected: ");
+        String separator = " ";
+        for (String failure : failures) {
+            sb.append(separator);
+            separator = ", ";
+            sb.append(failure);
+        }
+
+        return sb.toString();
+    }
+
+    private void finishDeferred() {
+        Timer delayer = new Timer();
+        delayer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                activity.finish();
+            }
+        }, 1000);
+    }
+}

--- a/wearossensors/src/main/java/es/uji/geotec/wearossensors/permissions/handler/PermissionsResult.java
+++ b/wearossensors/src/main/java/es/uji/geotec/wearossensors/permissions/handler/PermissionsResult.java
@@ -1,0 +1,5 @@
+package es.uji.geotec.wearossensors.permissions.handler;
+
+public interface PermissionsResult {
+    void onPermissionsRequestResult(boolean success);
+}


### PR DESCRIPTION
This PR integrates in the library a two-step permissions request workflow required when requesting special permissions such as `BODY_SENSORS_BACKGROUND` and `ACCESS_BACKGROUND_LOCATION`. 

Android allows to request several permissions at once. However, special permissions require other permissions to be granted in order to be requested. For example, the `BODY_SENSORS` permission has to be granted before requesting `BODY_SENSORS_BACKGROUND`. In other words, a two-step workflow has to be implemented: 

1. Request normal permission.
2. If granted, request special permission.

This is a non-trivial workflow. Therefore, the library provides the `PermissionsRequestHandler`, providing functions implementing the workflow. 