### PR TITLE
Support for Wear OS 5 (Android 14 - API 34)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,5 +38,5 @@ jobs:
       - name: Publish package
         run: ./gradlew publish -Psigning.keyId=${{secrets.OSSRH_GPG_SECRET_KEY_ID}} -Psigning.password=${{secrets.OSSRH_GPG_SECRET_KEY_PASSWORD}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg) --warn --stacktrace
         env:
-          OSSRH_USERNAME: ${{secrets.OSSRH_USERNAME}}
-          OSSRH_PASSWORD: ${{secrets.OSSRH_PASSWORD}}
+          OSSRH_TOKEN: ${{secrets.OSSRH_TOKEN}}
+          OSSRH_TOKEN_PASSWORD: ${{secrets.OSSRH_TOKEN_PASSWORD}}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To install the library you have to add the dependency in your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'io.github.geotecinit:wear-os-sensors:1.2.0'
+    implementation 'io.github.geotecinit:wear-os-sensors:1.3.0'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,12 +12,12 @@ android {
         }
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "es.uji.geotec.wearossensorsdemo"
         minSdk 23
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:exported="true">
+            android:exported="true"
+            android:taskAffinity="">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -39,6 +40,7 @@
         </activity>
         <activity android:name=".RequestPermissionsActivity"
             android:excludeFromRecents="true"
+            android:noHistory="true"
             android:taskAffinity="" />
     </application>
 

--- a/wearossensors/build.gradle
+++ b/wearossensors/build.gradle
@@ -92,8 +92,8 @@ publishing {
             url = isReleaseVersion ? releaseRepo : snapshotRepo
 
             credentials {
-                username = findProperty("ossrhUsername") ?: System.getenv("OSSRH_USERNAME")
-                password = findProperty("ossrhPassword") ?: System.getenv("OSSRH_PASSWORD")
+                username = findProperty("ossrhToken") ?: System.getenv("OSSRH_TOKEN")
+                password = findProperty("ossrhTokenPassword") ?: System.getenv("OSSRH_TOKEN_PASSWORD")
             }
 
             mavenContent {

--- a/wearossensors/build.gradle
+++ b/wearossensors/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
-        minSdkVersion 23
-        targetSdkVersion 33
+        minSdk 23
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -39,7 +39,7 @@ android {
     namespace 'es.uji.geotec.wearossensors'
 }
 
-version = '1.2.1'
+version = '1.3.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 publishing {
@@ -115,7 +115,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-wearable:18.1.0'
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'com.google.android.gms:play-services-location:20.0.0'
-    api 'io.github.geotecinit:background-sensors:1.3.0'
+    api 'io.github.geotecinit:background-sensors:1.4.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/wearossensors/src/main/AndroidManifest.xml
+++ b/wearossensors/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application>
         <service android:name=".services.SensorMessagingListenerService" android:exported="true">
@@ -36,6 +37,11 @@
             </intent-filter>
         </service>
 
-        <service android:name=".services.WearSensorRecordingService" android:exported="true" />
+        <service android:name=".services.WearSensorRecordingService"
+            android:foregroundServiceType="specialUse"
+            android:exported="true">
+            <property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Foreground service for handling data collection from sensors."/>
+        </service>
     </application>
 </manifest>

--- a/wearossensors/src/main/AndroidManifest.xml
+++ b/wearossensors/src/main/AndroidManifest.xml
@@ -10,30 +10,14 @@
         <service android:name=".services.SensorMessagingListenerService" android:exported="true">
             <intent-filter>
                 <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
-                <data
-                    android:host="*"
-                    android:pathPattern="/advertise-capabilities"
-                    android:scheme="wear" />
-                <data
-                    android:host="*"
-                    android:pathPattern="/.*/ready"
-                    android:scheme="wear" />
-                <data
-                    android:host="*"
-                    android:pathPattern="/.*/prepare"
-                    android:scheme="wear" />
-                <data
-                    android:host="*"
-                    android:pathPattern="/.*/start"
-                    android:scheme="wear" />
-                <data
-                    android:host="*"
-                    android:pathPattern="/.*/stop"
-                    android:scheme="wear" />
-                <data
-                    android:host="*"
-                    android:pathPattern="/plain-message.*"
-                    android:scheme="wear" />
+                <data android:scheme="wear"/>
+                <data android:host="*"/>
+                <data android:pathPattern="/advertise-capabilities"/>
+                <data android:pathPattern="/.*/ready"/>
+                <data android:pathPattern="/.*/prepare"/>
+                <data android:pathPattern="/.*/start"/>
+                <data android:pathPattern="/.*/stop"/>
+                <data android:pathPattern="/plain-message.*"/>
             </intent-filter>
         </service>
 


### PR DESCRIPTION
This PR adds support for Wear OS smartwatches running Wear OS 5 (Android 14 - API 34). 

The PR sets the mandatory service type attribute for foreground services, as indicated in #11. Since no already defined service type matches 100% of all possible data collection aims, a special service type is defined. The service type might change in the future if Android defines a foreground service type that matches the purpose of the library.

---

In addition, the PR includes changes in the GitHub Action used for publishing the library.